### PR TITLE
stopped bad searches from entering history

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -1,7 +1,27 @@
-// const psKey = "561b5fdd2c9ef31ec83be9783559e272";
+// const psKey = "561b5fdd2c9ef31ec83be9783559e272"; 
 const oWKey = 'b40a49b598146847ec7cdb4601c0bec0';
 var chargerInfo = [];
 var searchHistory = JSON.parse(localStorage.getItem("History")) || [];
+
+function init() {
+  displaySearchHistory();
+  document.getElementById("form").addEventListener("submit", function (event) {
+    event.preventDefault();
+    getData(document.getElementById("usercity").value, document.getElementById("mileslider").value);
+    document.getElementById("usercity").value = '';
+  });
+
+  document.getElementById("searchhistory").addEventListener("click", function (event) {
+    getData(event.target.getAttribute("data-location"), event.target.getAttribute("data-range"))
+  })
+
+  window.onclick = function(e){
+    if(e.target === document.querySelector('#errorModal')){
+      document.querySelector('#errorModal').style.display = 'none'
+    }
+  }
+
+}
 
 function getData(address, distance) {
   chargerInfo = [];
@@ -12,10 +32,10 @@ function getData(address, distance) {
       return response.json();
     })
     .then(function (oWData) {
-      if (oWData.cod === '404'){
+      if (oWData.cod === '404') {
         callModal();
         return;
-    }
+      }
       var lat = oWData.coord.lat;
       var lon = oWData.coord.lon;
       ocUrl = `https://api.openchargemap.io/v3/poi/?output=json&latitude=${lat}&longitude=${lon}&distance=${distance}`;
@@ -24,6 +44,8 @@ function getData(address, distance) {
           return response.json();
         })
         .then(function (ocData) {
+          saveSearchHistory(address, distance);
+          displaySearchHistory();
           for (let i = 0; i < ocData.length; i++) {
             chargerInfo.push({});
             chargerInfo[i].title = ocData[i].AddressInfo.Title;
@@ -43,32 +65,6 @@ function getData(address, distance) {
           displayData();
         });
     });
-}
-
-// //populate search history
-//display data for last search
-//set up event listener for form submit
-//set up event listener for search history
-init();
-function init() {
-  displaySearchHistory();
-  document.getElementById("form").addEventListener("submit", function (event) {
-    event.preventDefault();
-    getData(
-      document.getElementById("usercity").value,
-      document.getElementById("mileslider").value
-    );
-    saveSearchHistory(
-      document.getElementById("usercity").value,
-      document.getElementById("mileslider").value
-    );
-    displaySearchHistory();
-  });
-
-document.getElementById("searchhistory").addEventListener("click", function(event){
-    getData(event.target.getAttribute("data-location"), event.target.getAttribute("data-range"))
-})
-
 }
 
 function saveSearchHistory(location, range) {
@@ -100,17 +96,15 @@ function displayData() {
     resultsCard.classList = "mt-2 border-2 border-blue-700 bg-indigo-400"; // add in classes once we know which we need
     resultsCard.innerHTML = `
             <h1 class="px-2">${chargerInfo[i].title}</h1>
-            <a class="px-2 underline hover:text-green-400 cursor-pointer" href="https://www.google.com/maps/place/${
-              chargerInfo[i].address +
-              chargerInfo[i].town +
-              chargerInfo[i].state +
-              chargerInfo[i].zip
-            }" target='_blank'>${chargerInfo[i].address} ${
-      chargerInfo[i].town
-    }, ${chargerInfo[i].state} ${chargerInfo[i].zip}</a>
+            <a class="px-2 underline hover:text-green-400 cursor-pointer" href="https://www.google.com/maps/place/${chargerInfo[i].address +
+      chargerInfo[i].town +
+      chargerInfo[i].state +
+      chargerInfo[i].zip
+      }" target='_blank'>${chargerInfo[i].address} ${chargerInfo[i].town
+      }, ${chargerInfo[i].state} ${chargerInfo[i].zip}</a>
             <h4 class="px-2">Charger Types: ${chargerInfo[i].chargerType.join(
-              ", "
-            )}</h4>
+        ", "
+      )}</h4>
             `;
     document.getElementById("searchresults").appendChild(resultsCard);
   }
@@ -120,17 +114,16 @@ function sliderValue(val) {
   document.querySelector("#mileOutput").textContent = val + " Miles";
 }
 
-function callModal(){
-  document.querySelector('#errorModal').style.display  = 'block';
+function callModal() {
+  document.querySelector('#errorModal').style.display = 'block';
 }
 
-window.onclick = function(e){
-  if(e.target === document.querySelector('#errorModal')){
-    document.querySelector('#errorModal').style.display = 'none'
-  }
-}
+init();
+
 
 /*
+Logic Plan
+
 //init function
     //populate search history
     //display data for last search


### PR DESCRIPTION
Moved the saveSearchHistory and displaySearchHistory function calls inside of get data. This allows us to not save a search until we have verified we can get data from the apis on that search. Now a click from search history will also call these functions, but since we already have a clause set up to prevent duplicates from entering the search history it has no effect. 

Also moved the event listener to kill the modal into the init function (as we just need to set it up one time) and rearranged the functions so there's hopefully a logically flow through the code as you read it. 